### PR TITLE
chore(docker): update URLs after migration

### DIFF
--- a/sso-plugin/optimize-sso-keycloak/docker-compose.yml
+++ b/sso-plugin/optimize-sso-keycloak/docker-compose.yml
@@ -48,7 +48,7 @@ services:
        - keycloak
 
   engine:
-    image: registry.camunda.cloud/camunda-bpm-platform-ee:7.9.5
+    image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.9.5
     ports:
       - "8088:8080"
     networks:


### PR DESCRIPTION
- old URLs will continue to work for existing customers for the time being
- customers should adopt new URLs whenever possible

Related to INFRA-1092