### PR TITLE
fix(sso): correct mount path for license file

### DIFF
--- a/optimize-sso-keycloak-example/docker-compose.yml
+++ b/optimize-sso-keycloak-example/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - OPTIMIZE_ELASTICSEARCH_HOST=elasticsearch
     volumes:
       - ./optimize-config/environment-config.yaml:/optimize/config/environment-config.yaml
-      - ./optimize-config/OptimizeLicense.txt:/optimize/environment/OptimizeLicense.txt
+      - ./optimize-config/OptimizeLicense.txt:/optimize/config/OptimizeLicense.txt
       - ../plugins/sso-plugin/target/sso-plugin-jar-with-dependencies.jar:/optimize/plugin/sso.jar
     restart: always
     mem_limit: 2g


### PR DESCRIPTION
relates to #OPT-5718

needs to get backported to the 3.6.0 tag, will take care of that after approval