### PR TITLE
chore: use upsteam URL for cambpm-ee/camunda-bpm-platform-ee Docker image

### DIFF
--- a/rpa-monitoring/ui-path/docker-compose.yml
+++ b/rpa-monitoring/ui-path/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     restart: always
     mem_limit: 2g
   cambpm:
-    image: registry.camunda.cloud/camunda-bpm-platform-ee:7.14.0
+    image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.14.0
     container_name: cambpm
     environment:
       - TZ=Europe/Berlin


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/561.

The redirect from `registry.camunda.cloud/camunda-bpm-platform-ee` to  `registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee` will be deprecated and removed, and all references must be updated.

Thank you!
